### PR TITLE
Add openstack support for spark deployer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,8 @@ lazy val core = (project in file("core"))
       "net.ceedubs" %% "ficus" % "[1.0.1,1.1.2]",
       "com.github.seratch" %% "awscala" % "0.5.5" excludeAll(ExclusionRule(organization = "com.amazonaws")),
       "com.amazonaws" % "aws-java-sdk-s3" % "1.10.34",
-      "com.amazonaws" % "aws-java-sdk-ec2" % "1.10.34"
+      "com.amazonaws" % "aws-java-sdk-ec2" % "1.10.34",
+      "org.pacesys" % "openstack4j" % "2.0.9"
     )
   )
 

--- a/core/src/main/scala/sparkdeployer/OSMachines.scala
+++ b/core/src/main/scala/sparkdeployer/OSMachines.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sparkdeployer
+
+import Helpers.retry
+import org.slf4s.Logging
+import com.typesafe.config._
+import net.ceedubs.ficus.Ficus._
+
+import org.openstack4j.openstack.OSFactory
+import org.openstack4j.api._
+import org.openstack4j.model.compute._
+
+import scala.collection.JavaConverters._
+
+
+class OSMachines(config: Config) extends Machines with Logging {
+  class OSConf(config: Config) extends ClusterConf(config) {
+    //val networkIds = config.as[Set[String]]("network-ids").toSeq
+    val networkId = config.as[String]("network-id")
+    val imageId = config.as[String]("image-id")
+
+    val os_cacert = config.as[String]("os-cacert")
+    val os_auth_url = config.as[String]("os-auth-url")
+    val os_tenant_id = config.as[String]("os-tenant-id")
+    val os_tenant_name = config.as[String]("os-tenant-name")
+    val os_username = config.as[String]("os-username")
+    private val standardIn = System.console()
+    val os_password = standardIn.readPassword("Please enter password> ").mkString
+
+    // TODO: attach extra disk
+    //val rootDevice = config.as[Option[String]]("root-device").getOrElse("/dev/xvda")
+  }
+  implicit val clusterConf = new OSConf(config)
+
+  private def os(): OSClient = OSFactory.builder()
+    .endpoint(clusterConf.os_auth_url)
+    .credentials(clusterConf.os_username, clusterConf.os_password)
+    .tenantId(clusterConf.os_tenant_id)
+    .tenantName(clusterConf.os_tenant_name)
+    .useNonStrictSSLClient(true)
+    .authenticate()
+
+  def createMachines(machineType: MachineType, names: Set[String]): Seq[Machine] = {
+    log.info(s"[OpenStack] Creating ${names.size} instances...")
+    names.toSeq.map { name =>
+      val flavor = os().compute().flavors().list().asScala.find(_.getName() == (machineType match {
+        case Master => clusterConf.masterInstanceType
+        case Worker => clusterConf.workerInstanceType
+      })).get
+      val image = os().compute().images().get(clusterConf.imageId)
+
+      val bs = Builders.server()
+      val serverCreate: ServerCreate = clusterConf.securityGroupIds
+                              .map(ids => ids.toSeq.foldLeft(bs) {(bs, id) => bs.addSecurityGroup(id)}).get
+                              .name(name)
+                              .flavor(flavor)
+                              .image(image)
+                              .keypairName(clusterConf.keypair)
+                              //.networks(clusterConf.networkIds.toList.asJava)
+                              .networks(Seq(clusterConf.networkId).toList.asJava)
+                              .build();
+      log.info(s"[OpenStack] Creating instance '${name}' ...")
+      val server: Server = os().compute().servers().boot(serverCreate)
+      retry { i =>
+        log.info(s"[OpenStack] [${name}] Getting instance's address. Attempts: $i.")
+        val thatServer = os().compute().servers().list().asScala.find(_.getId() == server.getId()).get
+        val m = getMachine(thatServer)
+        assert(m.id != null)
+        assert(m.name != null)
+        assert(m.address != null)
+        m
+      }
+    }
+  }
+
+  private def getMachine(server: Server) = {
+    // not use first one
+    val networkName = os().networking().network().get(clusterConf.networkId).getName()
+    val addr = server.getAddresses().getAddresses(networkName).asScala.head.getAddr()
+    Machine(server.getId(), server.getName(), addr)
+  }
+
+  def getMachines(): Seq[Machine] = {
+    os().compute().servers().list().asScala.map { s =>
+      getMachine(s)
+    }
+  }
+
+  def destroyMachines(ids: Set[String]): Unit = {
+    val toKill = getMachines.filter { m => ids.contains(m.id) }
+    log.info(s"[OpenStack] Terminating ${toKill.size} instances.")
+    toKill.map { m =>
+      os().compute().servers().delete(m.id)
+    }
+    retry { i =>
+      log.info(s"[OpenStack] Checking status. Attempts: ${i}.")
+      val liveMachines = getMachines.filter { m => ids.contains(m.id) }
+      assert(liveMachines.size == 0)
+    }
+    log.info("[OpenStack] All instances are terminated.")
+  }
+}

--- a/core/src/main/scala/sparkdeployer/OSMachines.scala
+++ b/core/src/main/scala/sparkdeployer/OSMachines.scala
@@ -28,7 +28,6 @@ import scala.collection.JavaConverters._
 
 class OSMachines(config: Config) extends Machines with Logging {
   class OSConf(config: Config) extends ClusterConf(config) {
-    //val networkIds = config.as[Set[String]]("network-ids").toSeq
     val networkId = config.as[String]("network-id")
     val imageId = config.as[String]("image-id")
 
@@ -69,7 +68,6 @@ class OSMachines(config: Config) extends Machines with Logging {
                               .flavor(flavor)
                               .image(image)
                               .keypairName(clusterConf.keypair)
-                              //.networks(clusterConf.networkIds.toList.asJava)
                               .networks(Seq(clusterConf.networkId).toList.asJava)
                               .build();
       log.info(s"[OpenStack] Creating instance '${name}' ...")
@@ -87,7 +85,6 @@ class OSMachines(config: Config) extends Machines with Logging {
   }
 
   private def getMachine(server: Server) = {
-    // not use first one
     val networkName = os().networking().network().get(clusterConf.networkId).getName()
     val addr = server.getAddresses().getAddresses(networkName).asScala.head.getAddr()
     Machine(server.getId(), server.getName(), addr)

--- a/core/src/main/scala/sparkdeployer/SparkDeployer.scala
+++ b/core/src/main/scala/sparkdeployer/SparkDeployer.scala
@@ -31,7 +31,8 @@ class SparkDeployer(val config: Config) extends Logging {
   private val masterName = clusterConf.clusterName + "-master"
   private val workerPrefix = clusterConf.clusterName + "-worker"
 
-  private val machines = new EC2Machines(config)
+  private val machines =
+      if (clusterConf.platform == "ec2") new EC2Machines(config) else new OSMachines(config)
 
   //helper functions
   def getMasterOpt() = machines.getMachines.find(_.name == masterName)


### PR DESCRIPTION
I create OSMachines class for spark deployer to collaborate with openstack platform, it use openstack4j java API(http://openstack4j.com/) and has been tested on private cluster from National Taiwan University CS department(https://140.112.91.150/).